### PR TITLE
Streamline Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use the refactoring analysis dump found [here](https://github.com/ualberta-smr/r
 
 This evaluation repository already comes with the versions of IntelliMerge and RefMerge we use in the paper:
 
-- Our [fork of IntelliMerge](https://github.com/max-ellis/IntelliMerge/tree/evaluation), at commit [5966f75](https://github.com/max-ellis/IntelliMerge/commit/5966f75)
+- Our [fork of IntelliMerge](https://github.com/max-ellis/IntelliMerge/tree/evaluation), at commit [5966f75](https://github.com/max-ellis/IntelliMerge/commit/5966f75). Note that we had to fix some issues in IntelliMerge to be able to reproduce their results. We document these in in a [wiki page](https://github.com/max-ellis/IntelliMerge/wiki/Details) in our fork.
 - [RefMerge](https://github.com/ualberta-smr/RefMerge), [release 1.0.0](https://github.com/ualberta-smr/RefMerge/releases/tag/1.0.0)
 
 If you would like to use different versions than provided:

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# RefactoringAwareMergingEvaluation
+# Refactoring-aware Merging Evaluation
 
-In RefactoringAwareMergingEvaluation, we perform a quantitative comparison between operation-based refactoring-aware merging (implemented in RefMerge) and 
-graph-based refactoring-aware merging (implemented in IntelliMerge). Afterwards, we dive deeper into the results by manually sampling 50 merge scenarios and 
-investigate the conflicts that Git, RefMerge, and IntelliMerge report as well as what their causes are. This evaluation was used in the paper, "Refactoring-aware Operation-based Merging: An Empirical Evaluation" (http://arxiv.org/abs/2112.10370).
+This repository contains the evaluation setup and results for our TSE submission titled "Refactoring-aware Operation-based Merging: An Empirical Evaluation", also available on [arXiv](http://arxiv.org/abs/2112.10370).
 
-## RefMerge
+We perform a quantitative evaluation between operation-based refactoring-aware merging (implemented in [RefMerge](https://github.com/ualberta-smr/RefMerge)) and 
+graph-based refactoring-aware merging (implemented in [IntelliMerge](https://github.com/Symbolk/IntelliMerge)). Afterwards, we dive deeper into the results by manually sampling 50 merge scenarios and 
+investigate the conflicts that Git, RefMerge, and IntelliMerge report as well as what their causes are. 
 
-We implemented operation-based rerfactoring-aware merging in [RefMerge](https://github.com/ualberta-smr/RefMerge). RefMerge works by undoing refactorings, merging, and then replaying the refactorings. When merging, RefMerge considers the interactions between each pair of refactorings and how these interactions can lead to a conflict or how they can result in a dependence relationship. We provide the conflict and dependence detection logic for each pair in the [conflict detection wiki](https://github.com/ualberta-smr/RefMerge/wiki/Conflict-&-Dependence-Logic). 
+## Note about RefMerge
+
+We implemented operation-based rerfactoring-aware merging in [RefMerge](https://github.com/ualberta-smr/RefMerge). RefMerge works by undoing refactorings, merging, and then replaying the refactorings. When merging, RefMerge considers the interactions between each pair of refactorings and how these interactions can lead to a conflict or how they can result in a dependence relationship. The RefMerge repo provides detailed documentaiton on how it works. We provide the conflict and dependence detection logic for each pair in the [conflict detection wiki](https://github.com/ualberta-smr/RefMerge/wiki/Conflict-&-Dependence-Logic). 
 
 ## System requirements
+
 * Linux
 * git
 * Java 11
 * IntelliJ (Community Addition) Version 2020.1.2
 
-## How to run
+## Setup Steps for Running The Evaluation
 
 ### 1. Clone and build RefactoringMiner 
-Use `Git Clone https://github.com/tsantalis/RefactoringMiner.git` to clone RefactoringMiner. 
+Use `git clone https://github.com/tsantalis/RefactoringMiner.git` to clone RefactoringMiner. 
 Then build RefactoringMiner with `./gradlew distzip`. It will be under build/distributions.
 
 ### 2. Add RefactoringMiner to your local maven repository
@@ -27,66 +30,54 @@ to add it to your local maven repository. You can verify that it's been installe
 by checking the path `/home/username/.m2/repository/org/refactoringminer`.
 
 ### 3. Populate databases
-Use the refactoring analysis dump found [here](https://github.com/ualberta-smr/refactoring-analysis-results)
-to populate the original_analysis database. We use the original_analysis database to collect the 10 additional projects that we evaluate on.
-Use the `database/intelliMerge_data1`
-sql dump to populate intelliMerge_data1 database. This database contains the projects and merge scenarios used in IntelliMerge's evaluation.
-Use the database/refactoringAwareMerging_dataset to populate refactoringAwareMerging_dataset database. A description of how to populate the databases can be found 
+
+You next need to create and populate the databases needed to run this evaluation. These databases contain the information of the 20 projects we evaluate on. A detailed description of these databases and how to use the provided DB can be found 
 [here](https://github.com/ualberta-smr/RefactoringAwareMergingEvaluation/wiki/Datasets).
 
-## IntelliMerge Replication
+There are three databases, all provided in the `database/` folder:
 
-We use the IntelliMerge Replication to reproduce the IntelliMerge results as is with only the 10 projects in their paper.
+1. `intelliMerge_data1`: This database contains the 10 projects and merge scenarios used in IntelliMerge's evaluation.
+2. `original_analysis`: This is data collected by running the refactoring in merge scenarios pipeline developed by Mahmoudi et al., SANER '19. We use this data to select 10 additional projects for our evaluation. 
+Use the refactoring analysis dump found [here](https://github.com/ualberta-smr/refactoring-analysis-results)
+3. `database/refactoringAwareMerging_dataset`: This database ???
 
-### Using IntelliMerge
+### 4. Configure IntelliMerge and RefMerge
 
-This project comes with the version of IntelliMerge that we used to run the IntelliMerge replication, 
-found in our fork of IntelliMerge, https://github.com/max-ellis/IntelliMerge.git, at commit `5966f75`.
+This evaluation repository already comes with the versions of IntelliMerge and RefMerge we use in the paper:
 
-### Get IntelliMerge replication commits
-Run `python intelliMerge_data_resolver` to get the IntelliMerge commits used in
-the IntelliMerge replication. 
+- Our [fork of IntelliMerge](https://github.com/max-ellis/IntelliMerge/tree/evaluation), at commit [5966f75](https://github.com/max-ellis/IntelliMerge/commit/5966f75)
+- [RefMerge](https://github.com/ualberta-smr/RefMerge), [release 1.0.0](https://github.com/ualberta-smr/RefMerge/releases/tag/1.0.0)
 
-### Edit configuration
-Edit the configuration tasks to have `:runIde -Pmode=comparison -PdataPath=path 
--PevaluationProject=project`, where path is the path to the cloned test projects
-and project is the test project.
+If you would like to use different versions than provided:
 
-## RefactoringAwareMerging Comparison
+- For IntelliMerge, build the respective IntelliMerge version and include the resulting jar in the `lib` folder for this repository.
+- For RefMerge: After you clone and checkout the desired version of RefMerge you want to use, copy the code in `ca.ualberta.cs.smr.refmerge` and replace the code in the `ca.ualberta.cs.smr.refmerge` package within this project (found [here](https://github.com/ualberta-smr/RefactoringAwareMergingEvaluation/tree/master/src/main/java/ca/ualberta/cs/smr/refmerge)) with it.
 
-### Using IntelliMerge and RefMerge
+### 5. Edit IntelliJ Configurations
 
-This project comes with the versions of IntelliMerge and RefMerge used in the paper. The source code for 
-the version of IntelliMerge we used is the same as that in our IntelliMerge replication.
- If you would like to use a different version of IntelliMerge, build the respective IntelliMerge version 
-and copy and paste that version into the lib folder.
+This evaluation runs within IntelliJ. Edit the configuration tasks in the IntelliJ IDE under `Run | Edit Configurations` (more information can be found [here](https://www.jetbrains.com/help/idea/run-debug-configuration.html#create-permanent)) to have `:runIde` and include set `-Pmode=` to `comparison`.
 
-RefMerge's history can be found here: https://github.com/ualberta-smr/RefMerge.git. The
-version used within this evaluation is release 1.0.0 in commit `adb13ff`.
-If you would like to use a different version of
-RefMerge, you first need to clone RefMerge. After you clone RefMerge, copy the code in
-`ca.ualberta.cs.smr.refmerge` and replace the code in the `ca.ualberta.cs.smr.refmerge` package within this project (found [here](https://github.com/ualberta-smr/RefactoringAwareMergingEvaluation/tree/master/src/main/java/ca/ualberta/cs/smr/refmerge)).
 
-### Edit configuration
-Edit the configuration tasks in the IntelliJ IDE under `Run | Edit Configurations` (more information can be found [here](https://www.jetbrains.com/help/idea/run-debug-configuration.html#create-permanent)) to have `:runIde` and include set `-Pmode=` to `comparison`.
-Then, set `-PevaluationProject=` to the project that you want to evaluate on. For example,
-it would look like `-PevaluationProject=error-prone` if you want to evaluate on error-prone.
-
-### RQ1 data
+## Reproducing RQ1
 
 The projects we evaluated on can be found in the file `experiment_data/refMerge_evaluation_projects`. A list of merge scenarios and their corresponding projects that we evaluated on are located in `experiment_data/refMerge_evaluation_commits`.
 
 ### Running RQ1 experiment
 
-To replicate RQ1, first run `python project_sampler` to get the additional 10 projects used 
-in the evaluation. Then, run `python refMerge_data_resolver` to get the commits with
+To reproduce RQ1:
+
+1. `cd stats/`
+2. Run `python project_sampler.py` to get the additional 10 projects used 
+in the evaluation. 
+3. Run `python refMerge_data_resolver.py` to get the commits with
 refactoring-related conflicts.
+4. Put the `refMerge_evaluation_commits` file generated by `refMerge_data_resolver` in the `src/main/resources` folder. 
 
-Put the `stats/refMerge_evaluation_commits` file generated by `refMerge_data_resolver` in the resources folder. While running the evaluation, you have to manually load each project but after that the evaluation is automated. For each project, you will need to do the following:
+While running the evaluation, you have to manually load each project but after loading the project, the rest of the evaluation is automated. For each project, you will need to do the following:
 
-1. Add the corresponding evaluation project to the configuration in the IntelliJ IDE under `Run | Edit Configurations`. For example, `-PevaluationProject=error-prone`. 
+1. Add the corresponding evaluation project to the configuration in the IntelliJ IDE under `Run | Edit Configurations`. For example, `-PevaluationProject=error-prone` to evaluate on error-prone.
 
-2. Clone the corresponding evaluation project.
+2. Clone the corresponding evaluation project (e.g., error-prone).
 
 3. Open the evaluation project with the IntelliJ IDEA in a new window. 
 
@@ -96,16 +87,21 @@ Put the `stats/refMerge_evaluation_commits` file generated by `refMerge_data_res
 
 6. Wait for the evaluation pipeline to finish processing that project.
 
-The data from the evaluation pipeline will be stored in the database, `refMerge_evaluation`. The evaluation pipeline will create the database if it does not already exist. Finally, use the scripts in evaluation_data_plotter to get tables and plots from the data.
+The data from the evaluation pipeline will be stored in the database, `refMerge_evaluation`. The evaluation pipeline will create the database if it does not already exist. Finally, use the scripts in `stats/evaluation_data_plotter.py` to get tables and plots from the produced data.
+
+### RQ1 results
+
+The zip file, `database/refactoringAwareMerging_results.zip`, contains our results from running the evaluation pipeline for RQ1. A description of how to use these results can be found [here](https://github.com/ualberta-smr/RefactoringAwareMergingEvaluation/wiki/Datasets).
 
 
-### RQ2 data
+## Reproducing RQ2
 
 A list of merge scenarios and their corresponding projects that we used in RQ2 is stored in `experiment_data/rq2_scenarios`.
 
 ### Running RQ2 experiment
 
-First, use  the file `stats/evaluation_data_resolver` by running the command `python evaluation_data_resolver` to get the list of merge commit ids to sample. This will always result in the same merge scenarios when given the same data.
+- `cd stats` and run `python evaluation_data_resolver.py` to get the list of merge commit ids to sample. This will always result in the same merge scenarios when given the same data.
+
 This experiment is a manual analysis and we manually re-run the merge for each merge scenario. These are the steps that we follow for each merge scenario:
 
 1. Query the results in RQ1 using `SELECT * FROM merge_commit WHERE id = x` where x is the merge commit ID. Use this query to get the parent commits.
@@ -124,16 +120,25 @@ This experiment is a manual analysis and we manually re-run the merge for each m
 
 8. Record any additional notes about the discrepancies you find, such as the reasons for the discrepancies. 
 
-
-### RQ1 results
-
-The zip file, database/refactoringAwareMerging_results.zip, contains the results from
- running the evaluation pipeline for RQ1. A description of how to use these results can be 
- found [here](https://github.com/ualberta-smr/RefactoringAwareMergingEvaluation/wiki/Datasets).
- 
 ### RQ2 results
 
 The overall results for our manual analysis are stored in `results/manual_sampling_results.csv`. This includes the results for each merge scenario as well as reasons that we think each conflict falls into its corresponding category. The results used to produce the Git table in RQ2 are stored in `results/git_table.csv`. The results used for the RefMerge and IntelliMerge tables are respectively stored in `results/refMerge_table.csv` and `results/intelliMerge.csv`.
 
+## IntelliMerge Replication
 
+We use the IntelliMerge Replication to reproduce the IntelliMerge results as is with only the 10 projects in their paper.
+
+### Using IntelliMerge
+
+This project comes with the version of IntelliMerge that we used to run the IntelliMerge replication, 
+found in our fork of IntelliMerge, https://github.com/max-ellis/IntelliMerge.git, at commit `5966f75`.
+
+### Get IntelliMerge replication commits
+Run `python intelliMerge_data_resolver` to get the IntelliMerge commits used in
+the IntelliMerge replication. 
+
+### Edit configuration
+Edit the configuration tasks to have `:runIde -Pmode=comparison -PdataPath=path 
+-PevaluationProject=project`, where path is the path to the cloned test projects
+and project is the test project.
 

--- a/README.md
+++ b/README.md
@@ -142,3 +142,10 @@ Edit the configuration tasks to have `:runIde -Pmode=comparison -PdataPath=path
 -PevaluationProject=project`, where path is the path to the cloned test projects
 and project is the test project.
 
+## Contributors
+
+- [Max Ellis](https://github.com/max-ellis) (main developer)
+- [Sarah Nadi](https://sarahnadi.org/)
+- [Danny Dig](http://dig.cs.illinois.edu/)
+
+Please open an Issue for any problems/questions.


### PR DESCRIPTION
I also have the following additional comments/questions:

- You created the wiki page in your IntelliMerge fork, right? Can you include a proper title/description to indicate that these are your changes? and perhaps link to that in the ReadMe.

- The RefMerge release links to january.. you updated for the revision after that, can you link to new version?

- Which version/commit of RefactoringMiner did you use?

"It will be under build/distributions." --> what is it?

I am confused about Step 3. Is this creating new databases to reproduce our results from scratch or is this populating the DBs with our existing evaluation data for examination?

"Use the refactoring analysis dump found [here](https://github.com/ualberta-smr/refactoring-analysis-results)
to populate the `original_analysis` database." --> but this dump is from 2018. We re-ran it to collect the data. 

What is "refactoringAwareMerging_dataset"  ??

I don't understand what "IntelliMerge" replication section is in the ReadMe. Are these prereqs step I need to do before running? Or is this info on how we reproduced intellMerge? If the latter, perhaps this can be a separate doc/wiki page that is linked from here as extra info later in the ReadMe? so as not to disrupt the flow of how to run things? Because the next section already says that everything is in the repo. I changed the ReadMe to streamline things but I'm not sure if my changes are correct. I moved that section to the end but i'm still not sure where it belongs. 

"
4. Wait for IntelliJ to build the cloned project, then close it." --> close the project or what? If you close the project, how will the rest of the evaluation run? And what will run? Should you have opened the RefMerge or this repo in Intellij first? (like is there a missing step at the beginning here?)